### PR TITLE
Automating BiocCheck testing and website building

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -65,12 +65,26 @@ jobs:
         run: |
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
+          if (!require("BiocManager", quietly = TRUE))
+            install.packages("BiocManager")
+          BiocManager::install("BiocCheck")
         shell: Rscript {0}
 
-      - name: Check
+      - name: R CMD Check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "error", check_dir = "check")
+        run: 
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "error", check_dir = "check")
+          
+        shell: Rscript {0}
+        
+      - name: BiocCheck
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: |
+          library('BiocCheck')
+          BiocCheck::BiocCheck()
+        
         shell: Rscript {0}
 
       - name: Upload check results

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,0 +1,40 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: Rscript -e 'pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)'
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/R/setBound.R
+++ b/R/setBound.R
@@ -16,8 +16,7 @@
 #' @return \item{bound}{ A vector giving the values of a default sequence
 #' \eqn{\gamma_i} of nonnegative numbers.}
 #'   
-#' @keywords internal
-#' @export
+#' @noRd
 
 setBound <- function(alg, alpha = 0.05, N) {
   

--- a/R/setBound.R
+++ b/R/setBound.R
@@ -7,7 +7,6 @@
 #'   LORDdep, SAFFRON, ADDIS, LONDstar, LORDstar, SAFFRONstar, or
 #'   Alpha_investing
 #'
-#' @keywords internal
 #'
 #' @param alpha Overall significance level of the FDR procedure, the default is
 #'   0.05. The bounds for LOND and LORDdep depend on alpha.
@@ -17,6 +16,7 @@
 #' @return \item{bound}{ A vector giving the values of a default sequence
 #' \eqn{\gamma_i} of nonnegative numbers.}
 #'   
+#' @keywords internal
 #' @export
 
 setBound <- function(alg, alpha = 0.05, N) {

--- a/R/setBound.R
+++ b/R/setBound.R
@@ -7,6 +7,8 @@
 #'   LORDdep, SAFFRON, ADDIS, LONDstar, LORDstar, SAFFRONstar, or
 #'   Alpha_investing
 #'
+#' @keywords internal
+#'
 #' @param alpha Overall significance level of the FDR procedure, the default is
 #'   0.05. The bounds for LOND and LORDdep depend on alpha.
 #'


### PR DESCRIPTION
### BiocCheck testing

Fairly self-explanatory, this runs the relevant tests (ie. the one BioConductor requires that CRAN would not) as a separate sub-workflow to `R cmd check`

### Website building

Ideally, the website would rebuild everytime a PR was merged. This would mean that API changes get filed into the documentation as they come in. **Currently broken** but will use this PR as a place to gather thoughts before fixing locally.